### PR TITLE
ci: replace AWS static credentials with OIDC role assumption

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,8 +53,6 @@ jobs:
         role-to-assume: ${{ vars.AWS_IAM_ROLE }}
         aws-region: ${{ vars.AWS_DEFAULT_REGION }}
     - name: Test, format, lint
-      env:
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       run: |
         mkdir .mypy_cache
         pdm run prebuild

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,11 +44,17 @@ jobs:
       run: |
         pdm install -G dev
         
+    - name: Configure aws credentials
+      env:
+        AWS_IAM_ROLE: ${{ vars.AWS_IAM_ROLE }}
+        AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ vars.AWS_IAM_ROLE }}
+        aws-region: ${{ vars.AWS_DEFAULT_REGION }}
     - name: Test, format, lint
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
         mkdir .mypy_cache
         pdm run prebuild


### PR DESCRIPTION
Replaces `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` static credential env vars with `aws-actions/configure-aws-credentials@v6` action using IAM role assumption via OIDC.
